### PR TITLE
CBBI-287: Update Jenkinsfile for new build server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,7 @@
 /**
  * <p>
  * This is the script that will be run by Jenkins to build and test this 
- * project. This drives the project's continuous integration, delivery, and
- * deployment.
+ * project. This drives the project's continuous integration and delivery.
  * </p>
  * <p>
  * This script is run by Jenkins' Pipeline feature. A good intro tutorial for

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ def readPomVersion() {
  */
 def calculateBuildId() {
 	gitBranchName = "${env.BRANCH_NAME}".toString()
-	gitCommitId = sh(script: "git rev-parse HEAD > .git/current-commit", returnStdout: true).trim()
+	gitCommitId = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
 
 	buildId = ""
 	if("master".equals(gitBranchName)) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,13 +26,13 @@ node {
 	}
 
 	stage('Build') {
-		mvn "--update-snapshots -Dmaven.test.failure.ignore clean deploy"
+		mvn "--update-snapshots -Dmaven.test.failure.ignore clean install"
 	}
 
 	stage('Archive') {
 		// Fingerprint the output artifacts and archive the test results.
 		// (Archiving the artifacts here would waste space, as the build
-		// deploys them to the artifact repository.)
+		// deploys them to the local Maven repository.)
 		fingerprint '**/target/*.jar'
 		archiveArtifacts artifacts: '**/target/*-reports/TEST-*.xml', allowEmptyArchive: true, fingerprint: true
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,8 +80,7 @@ def readPomVersion() {
  */
 def calculateBuildId() {
 	gitBranchName = "${env.BRANCH_NAME}".toString()
-	sh(script: "git rev-parse HEAD > .git/current-commit", returnStdout: "gitCommitId")
-	gitCommitId = gitCommitId.trim()
+	gitCommitId = sh(script: "git rev-parse HEAD > .git/current-commit", returnStdout: true).trim()
 
 	buildId = ""
 	if("master".equals(gitBranchName)) {


### PR DESCRIPTION
Only a few functional changes from before:

1. It actually builds on the new Jenkins server (which is, you know, helpful).
2. The always-use-a-custom-version logic has switched from using Jenkins builds numbers to using Git commit hashes. As we've illustrated, Jenkins servers die and go away, but commit hashes are more or less permanent.
3. We aren't yet ready to `mvn deploy` on this new build server, so we just `mvn install`, instead.