### PR TITLE
CBBI-287: Ensure that JUnit log files are archived

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,7 @@ node {
 		// deploys them to the local Maven repository.)
 		fingerprint '**/target/*.jar'
 		junit testResults: '**/target/*-reports/TEST-*.xml', keepLongStdio: true
+		archiveArtifacts artifacts: '**/target/*-reports/*.txt', allowEmptyArchive: true
 	}
 }
 


### PR DESCRIPTION
They're often needed to diagnose test failures, and if they're not archived, Jenkins will dispose of them.

https://issues.hhsdevcloud.us/browse/CBBI-287