### PR TITLE
CBBF-97: Fix Codebook Variable.id typo for NCH_CLM_PRVDT_PMT_AMT

### DIFF
--- a/bluebutton-data-model-codebook-extractor/src/test/java/gov/hhs/cms/bluebutton/data/codebook/unmarshall/CodebookVariableReaderIT.java
+++ b/bluebutton-data-model-codebook-extractor/src/test/java/gov/hhs/cms/bluebutton/data/codebook/unmarshall/CodebookVariableReaderIT.java
@@ -22,6 +22,9 @@ public final class CodebookVariableReaderIT {
 		Map<String, Variable> variablesById = CodebookVariableReader.buildVariablesMappedById();
 		Assert.assertNotNull(variablesById);
 		Assert.assertFalse(variablesById.isEmpty());
+
+		for (Variable variable : variablesById.values())
+			assertVariableIsFixed(variable);
 	}
 
 	/**
@@ -37,5 +40,29 @@ public final class CodebookVariableReaderIT {
 			Assert.assertNotNull(variable.getCodebook().getName());
 			Assert.assertNotNull(variable.getCodebook().getVersion());
 		}
+	}
+
+	/**
+	 * Asserts that the specified {@link Variable} has been fixed (if it needed to
+	 * be).
+	 *
+	 * @param variable
+	 *            the {@link Variable} to validate
+	 */
+	private static void assertVariableIsFixed(Variable variable) {
+		/*
+		 * As fixes are added to CodebookPdfToXmlApp, an assertion method for each fix
+		 * should be added here.
+		 */
+
+		assertTypoFixForNchClmPrvdtPmtAmt(variable);
+	}
+
+	/**
+	 * @param variable
+	 *            the {@link Variable} to check
+	 */
+	private static void assertTypoFixForNchClmPrvdtPmtAmt(Variable variable) {
+		Assert.assertNotEquals("NCH_CLM_PRVDT_PMT_AMT", variable.getId());
 	}
 }


### PR DESCRIPTION
Should be `NCH_CLM_PRVDR_PMT_AMT`, instead.

Right now this looks over-engineered, but I know there are other problems with the PDF/parsing that we'll need to fix down the road. This was just the first problem that became a blocker. Wanted to put a framework in place for fixing all of those other problems when we get to them.

https://issues.hhsdevcloud.us/browse/CBBF-97