### PR TITLE
BLUEBUTTON-256: Fix creation of BeneficiariesHistory_hicn_idx

### DIFF
--- a/bluebutton-data-model-rif/src/main/resources/db/migration/V9__Create_beneficiary_history_table.sql
+++ b/bluebutton-data-model-rif/src/main/resources/db/migration/V9__Create_beneficiary_history_table.sql
@@ -24,5 +24,5 @@ ${logic.tablespaces-escape} tablespace "beneficiaries_ts"
  */
 create sequence beneficiaryHistory_beneficiaryHistoryId_seq ${logic.sequence-start} 1 ${logic.sequence-increment} 50;
 
-create index ${logic.index-create-concurrently} "BeneficiariesHistory_hicn_idx"
+create index "BeneficiariesHistory_hicn_idx"
   on "BeneficiariesHistory" ("hicn");


### PR DESCRIPTION
The rest of the migration is serial and transactional, so this was blowing up the migration. Not sure why, but Flyway doesn't like that scenario.

https://jira.cms.gov/browse/BLUEBUTTON-256