### PR TITLE
BLUEBUTTON-507: Switch synthetic data to latest version

### DIFF
--- a/bluebutton-data-model-rif-samples/src/main/java/gov/hhs/cms/bluebutton/data/model/rif/samples/TestDataSetLocation.java
+++ b/bluebutton-data-model-rif-samples/src/main/java/gov/hhs/cms/bluebutton/data/model/rif/samples/TestDataSetLocation.java
@@ -4,7 +4,7 @@ package gov.hhs.cms.bluebutton.data.model.rif.samples;
  * Enumerates the locations of various test data sets in S3.
  */
 public enum TestDataSetLocation {
-	SYNTHETIC_DATA("data-synthetic/2017-11-27T00:00:00.000Z-fixed"),
+	SYNTHETIC_DATA("data-synthetic/2017-11-27T00:00:00.000Z-fixed-with-negative-ids"),
 
 	DUMMY_DATA_1000000_BENES("data-random/1000000-beneficiaries-2017-10-21T00:00:00.000Z"),
 


### PR DESCRIPTION
Now have a version of it with negative PKs that shouldn't conflict with production data, ever. (Separately added a `SyntheticDataFixer2` to `bluebutton-data-pipeline` that makes that change: <https://github.com/CMSgov/bluebutton-data-pipeline/pull/145>.)

https://jira.cms.gov/browse/BLUEBUTTON-507