### PR TITLE
BLUEBUTTON-1031: Revert "Temp hack: allow out-of-order Flyway migrations"

### DIFF
--- a/bluebutton-data-model-rif/src/main/java/gov/hhs/cms/bluebutton/data/model/rif/schema/DatabaseSchemaManager.java
+++ b/bluebutton-data-model-rif/src/main/java/gov/hhs/cms/bluebutton/data/model/rif/schema/DatabaseSchemaManager.java
@@ -50,11 +50,6 @@ public final class DatabaseSchemaManager {
 		// Trying to prevent career-limiting mistakes.
 		flyway.setCleanDisabled(true);
 
-		// Resolve https://jira.cms.gov/browse/BLUEBUTTON-1031: apply migration 15 after
-		// 16 & 17.
-		// FIXME: remove after that's been addressed
-		flyway.setOutOfOrder(true);
-
 		flyway.setDataSource(dataSource);
 		flyway.setPlaceholders(createScriptPlaceholdersMap(dataSource));
 		flyway.migrate();


### PR DESCRIPTION
This reverts commit a94966744d7a0c0c1ac5ee0a517389ed646c0024.

Once it's been deployed everywhere (thus allowing V15 to be applied), it needs to be reverted.

https://jira.cms.gov/browse/BLUEBUTTON-1031