### PR TITLE
BLUEBUTTON-1115: Fixed v19 migration and added revert script

### DIFF
--- a/bluebutton-data-model-rif/src/main/resources/db/migration/V19__Add_inner_join_relationships.sql
+++ b/bluebutton-data-model-rif/src/main/resources/db/migration/V19__Add_inner_join_relationships.sql
@@ -12,6 +12,7 @@
  * first place: we can't use them, and they prevent us from having a foreign key (and JPA 
  * relationship) on this table.
  */
+
 create table "BeneficiariesHistoryInvalidBeneficiaries" (
   "beneficiaryHistoryId" bigint not null,
   "beneficiaryId" varchar(15),
@@ -24,24 +25,18 @@ create table "BeneficiariesHistoryInvalidBeneficiaries" (
 )
 ${logic.tablespaces-escape} tablespace "beneficiaries_ts"
 ;
+
 insert into "BeneficiariesHistoryInvalidBeneficiaries"
-  select
-    "BeneficiariesHistory"."beneficiaryHistoryId",
-  	"Beneficiaries"."beneficiaryId",
-  	"BeneficiariesHistory"."birthDate",
-  	"BeneficiariesHistory"."hicn",
-  	"BeneficiariesHistory"."sex",
-  	"BeneficiariesHistory"."hicnUnhashed",
-  	"BeneficiariesHistory"."medicareBeneficiaryId"
+  select "BeneficiariesHistory".*
     from "BeneficiariesHistory"
     left join "Beneficiaries"
       on "BeneficiariesHistory"."beneficiaryId" = "Beneficiaries"."beneficiaryId"
     where "Beneficiaries"."beneficiaryId" is NULL;
 delete
   from "BeneficiariesHistory"
-  where exists (select 1 
-  				from "BeneficiariesHistoryInvalidBeneficiaries"
-  				where "BeneficiariesHistoryInvalidBeneficiaries"."beneficiaryId" = "BeneficiariesHistory"."beneficiaryId");
+  where "beneficiaryHistoryId" in (
+    select "beneficiaryHistoryId" from "BeneficiariesHistoryInvalidBeneficiaries"
+  );
 
 alter table "BeneficiariesHistory" 
   add constraint "BeneficiariesHistory_beneficiaryId_to_Beneficiary" 
@@ -71,33 +66,18 @@ create table "MedicareBeneficiaryIdHistoryInvalidBeneficiaries" (
 )
 ${logic.tablespaces-escape} tablespace "beneficiaries_ts"
 ;
+
 insert into "MedicareBeneficiaryIdHistoryInvalidBeneficiaries"
-  select
-    "MedicareBeneficiaryIdHistory"."medicareBeneficiaryIdKey",
-  	"Beneficiaries"."beneficiaryId",
-  	"MedicareBeneficiaryIdHistory"."claimAccountNumber",
-  	"MedicareBeneficiaryIdHistory"."beneficiaryIdCode",
-  	"MedicareBeneficiaryIdHistory"."mbiSequenceNumber",
- 	"MedicareBeneficiaryIdHistory"."medicareBeneficiaryId",
- 	"MedicareBeneficiaryIdHistory"."mbiEffectiveDate",
- 	"MedicareBeneficiaryIdHistory"."mbiEndDate",
- 	"MedicareBeneficiaryIdHistory"."mbiEffectiveReasonCode",
- 	"MedicareBeneficiaryIdHistory"."mbiEndReasonCode",
- 	"MedicareBeneficiaryIdHistory"."mbiCardRequestDate",
-	"MedicareBeneficiaryIdHistory"."mbiAddUser",
- 	"MedicareBeneficiaryIdHistory"."mbiAddDate",
- 	"MedicareBeneficiaryIdHistory"."mbiUpdateUser",
-	"MedicareBeneficiaryIdHistory"."mbiUpdateDate",
- 	"MedicareBeneficiaryIdHistory"."mbiCrntRecIndId"
+  select "MedicareBeneficiaryIdHistory".*
     from "MedicareBeneficiaryIdHistory"
     left join "Beneficiaries"
       on "MedicareBeneficiaryIdHistory"."beneficiaryId" = "Beneficiaries"."beneficiaryId"
     where "Beneficiaries"."beneficiaryId" is NULL;
 delete
   from "MedicareBeneficiaryIdHistory"
-  where exists (select 1
-  				from "MedicareBeneficiaryIdHistoryInvalidBeneficiaries"
-  				where "MedicareBeneficiaryIdHistoryInvalidBeneficiaries"."beneficiaryId" = "MedicareBeneficiaryIdHistory"."beneficiaryId");
+  where "medicareBeneficiaryIdKey" in (
+    select "medicareBeneficiaryIdKey" from "MedicareBeneficiaryIdHistoryInvalidBeneficiaries"
+  );
 
 alter table "MedicareBeneficiaryIdHistory" 
    add constraint "MedicareBeneficiaryIdHistory_beneficiaryId_to_Beneficiary" 

--- a/bluebutton-data-model-rif/src/main/resources/db/scripts/Flyway_revert_v19_goof.sql
+++ b/bluebutton-data-model-rif/src/main/resources/db/scripts/Flyway_revert_v19_goof.sql
@@ -1,0 +1,31 @@
+/*
+ * Reverts the original version of the V19 migratio, which failed in TEST and
+ * PROD, but succeeded in DPR (and so needs to be manually rolled back there).
+ * 
+ * Note: In general, this is a bad idea: Flyway's documentation **really**
+ * tries to talk you out of stuff like this. On the other hand, I'm not sure we
+ * have any other options to recover from a migration that worked in some
+ * environments but failed in others. Also, this feels like a handy thing to
+ * have practiced. Worst case: we incur some downtime in DPR while restoring it
+ * from a backup.
+ * 
+ * See: https://jira.cms.gov/browse/BLUEBUTTON-1115
+ */
+
+BEGIN;
+
+ALTER TABLE "BeneficiariesHistory" 
+  DROP CONSTRAINT "BeneficiariesHistory_beneficiaryId_to_Beneficiary";
+INSERT INTO "BeneficiariesHistory"
+  SELECT * FROM "BeneficiariesHistoryInvalidBeneficiaries";
+DROP TABLE "BeneficiariesHistoryInvalidBeneficiaries";
+
+ALTER TABLE "MedicareBeneficiaryIdHistory" 
+   DROP CONSTRAINT "MedicareBeneficiaryIdHistory_beneficiaryId_to_Beneficiary";
+INSERT INTO "MedicareBeneficiaryIdHistory"
+  SELECT * FROM "MedicareBeneficiaryIdHistoryInvalidBeneficiaries";
+DROP TABLE "MedicareBeneficiaryIdHistoryInvalidBeneficiaries";
+
+DELETE FROM schema_version WHERE version = '19';
+
+COMMIT;


### PR DESCRIPTION
So. The original V19 migration failed in TEST and PROD, but succeeded in DPR. That's... a tricky situation.

This is my current best idea for fixing things back up:
1. Run a manual revert of V19 in DPR.
2. After that, merge and deploy this change, with a fixed V19 migration, which should succeed in all environments.

I've tested the updated migration by hand in TEST (manually, inside a transaction that I rolled back). I've also tested the revert-V19 script in DPR (manually, inside a transaction that I rolled back). Still, I'd really appreciate a review of these scripts for correctness.

**Warning**: Given the risks here, these changes should only be deployed during business hours when DBAs are available, in case something goes sideways.

https://jira.cms.gov/browse/BLUEBUTTON-1115